### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/RazzerDE/clank-dashboard/security/code-scanning/13](https://github.com/RazzerDE/clank-dashboard/security/code-scanning/13)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the steps in this workflow. This change ensures that the workflow has the minimum required permissions and mitigates potential security risks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
