### PR TITLE
Add Dependabot configuration for package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Configure Dependabot for npm and GitHub Actions updates on a weekly schedule.

### 🚀 Short Description
> This way, Dependabot checks weekly for new GitHub Action and npm updates, grouping them into a single pull request for each category. This means that up to two pull requests can be generated each week, accompanied by a table listing the dependencies being updated.